### PR TITLE
Page story update

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "build:typescript": "tsc --build packages/**/tsconfig.json",
+    "clean": "rm -rf */*/.tsbuildinfo packages/*/*.js packages/*/*.js.map packages/*/*.d.ts *.css.ts",
     "generate": "node scripts/generate.js",
     "serve": "node scripts/serve.js",
     "start": "yarn build && node scripts/watch.js --serve",

--- a/packages/pwc-button/src/pwc-button.ts
+++ b/packages/pwc-button/src/pwc-button.ts
@@ -51,9 +51,9 @@ export class PWCButton extends LitElement {
   disabled = false;
 
   /**
-   * Button kind. Corresponds to the attribute with the same name.
+   * Button variant
    */
-  @property({ reflect: true })
+  @property({ reflect: false })
   variant = BUTTON_KIND.PRIMARY;
 
   /**
@@ -72,9 +72,9 @@ export class PWCButton extends LitElement {
 
   protected render() {
     const { disabled, variant, class: additionalClass } = this;
-    const classes = classnames(additionalClass, `pf-c-button`, {
-      [`pf-m-${variant}`]: variant,
-    });
+    const classes = classnames(`pf-c-button`, {
+      [`pf-m-${variant}`]: variant
+    }, additionalClass);
     return html`
       <button id="button" class="${classes}" ?disabled=${disabled}><slot></slot></button>
     `;

--- a/packages/pwc-page/src/pwc-page-header-brand-link.ts
+++ b/packages/pwc-page/src/pwc-page-header-brand-link.ts
@@ -3,15 +3,24 @@ import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './pwc-page.css';
 
 /**
- * Page Header Brand Link.
+ * Page header brand link
  */
 @customElement('pwc-page-header-brand-link')
 export class PWCPageHeaderBrandLink extends LitElement {
+  protected defaultClass = 'pf-c-page__header-brand-link';
+
   /**
    * Additional button classes
    */
-  @property({ reflect: false })
-  class = '';
+  @property({ type: String, reflect: true })
+  class = this.defaultClass;
+
+  public attributeChangedCallback(name, oldval, newval) {
+    if (name === 'class') {
+      this.class = classnames(this.defaultClass, newval);
+      super.attributeChangedCallback(name, oldval, this.class);
+    }
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -22,10 +31,8 @@ export class PWCPageHeaderBrandLink extends LitElement {
   }
 
   protected render() {
-    const { class: additionalClass } = this;
-    const classes = classnames(additionalClass, 'pf-c-page__header-brand-link');
     return html`
-      <a class="${classes}"><slot></slot></a>
+      <a class="${this.defaultClass}"><slot></slot></a>
     `;
   }
 }

--- a/packages/pwc-page/src/pwc-page-header-brand-toggle.ts
+++ b/packages/pwc-page/src/pwc-page-header-brand-toggle.ts
@@ -3,15 +3,24 @@ import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './pwc-page.css';
 
 /**
- * Page Header Brand.
+ * Page header brand toggle
  */
 @customElement('pwc-page-header-brand-toggle')
 export class PWCPageHeaderBrandToggle extends LitElement {
+  protected defaultClass = 'pf-c-page__header-brand-link';
+
   /**
    * Additional button classes
    */
-  @property({ reflect: false })
-  class = '';
+  @property({ type: String, reflect: true })
+  class = this.defaultClass;
+
+  public attributeChangedCallback(name, oldval, newval) {
+    if (name === 'class') {
+      this.class = classnames(this.defaultClass, newval);
+      super.attributeChangedCallback(name, oldval, this.class);
+    }
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -22,10 +31,8 @@ export class PWCPageHeaderBrandToggle extends LitElement {
   }
 
   protected render() {
-    const { class: additionalClass } = this;
-    const classes = classnames(additionalClass, 'pf-c-page__header-brand-toggle');
     return html`
-      <div class="${classes}"><slot></slot></div>
+      <slot></slot>
     `;
   }
 }

--- a/packages/pwc-page/src/pwc-page-header-brand.ts
+++ b/packages/pwc-page/src/pwc-page-header-brand.ts
@@ -1,17 +1,26 @@
-// import classnames from 'classnames';
+import classnames from 'classnames';
 import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './pwc-page.css';
 
 /**
- * Page Header Brand.
+ * Page header brand
  */
 @customElement('pwc-page-header-brand')
 export class PWCPageHeaderBrand extends LitElement {
+  protected defaultClass = 'pf-c-page__header-brand';
+
   /**
    * Additional button classes
    */
-  @property({ reflect: false })
-  class = '';
+  @property({ type: String, reflect: true })
+  class = this.defaultClass;
+
+  public attributeChangedCallback(name, oldval, newval) {
+    if (name === 'class') {
+      this.class = classnames(this.defaultClass, newval);
+      super.attributeChangedCallback(name, oldval, this.class);
+    }
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -22,11 +31,6 @@ export class PWCPageHeaderBrand extends LitElement {
   }
 
   protected render() {
-    // const { class: additionalClass } = this;
-    // const classes = classnames(additionalClass, 'pf-c-page__header-brand');
-    // return html`
-    //   <div class="${classes}"><slot></slot></div>
-    // `;
     return html`
       <slot></slot>
     `;

--- a/packages/pwc-page/src/pwc-page-header-tools.ts
+++ b/packages/pwc-page/src/pwc-page-header-tools.ts
@@ -1,17 +1,26 @@
-// import classnames from 'classnames';
+import classnames from 'classnames';
 import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './pwc-page.css';
 
 /**
- * Page Header Tools.
+ * Page header tools
  */
 @customElement('pwc-page-header-tools')
 export class PWCPageHeaderTools extends LitElement {
+  protected defaultClass = 'pf-c-page__header-tools';
+
   /**
    * Additional button classes
    */
-  @property({ reflect: false })
-  class = '';
+  @property({ type: String, reflect: true })
+  class = this.defaultClass;
+
+  public attributeChangedCallback(name, oldval, newval) {
+    if (name === 'class') {
+      this.class = classnames(this.defaultClass, newval);
+      super.attributeChangedCallback(name, oldval, this.class);
+    }
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -22,11 +31,6 @@ export class PWCPageHeaderTools extends LitElement {
   }
 
   protected render() {
-    // const { class: additionalClass } = this;
-    // const classes = classnames(additionalClass, 'pf-c-page__header-tools');
-    // return html`
-    //   <div class="${classes}"><slot></slot></div>
-    // `;
     return html`
       <slot></slot>
     `;

--- a/packages/pwc-page/src/pwc-page-header.ts
+++ b/packages/pwc-page/src/pwc-page-header.ts
@@ -1,17 +1,26 @@
-// import classnames from 'classnames';
+import classnames from 'classnames';
 import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './pwc-page.css';
 
 /**
- * Page Header.
+ * Page header
  */
 @customElement('pwc-page-header')
 export class PWCPageHeader extends LitElement {
+  protected defaultClass = 'pf-c-page__header';
+
   /**
    * Additional button classes
    */
-  @property({ reflect: false })
-  class = '';
+  @property({ type: String, reflect: true })
+  class = this.defaultClass;
+
+  public attributeChangedCallback(name, oldval, newval) {
+    if (name === 'class') {
+      this.class = classnames(this.defaultClass, newval);
+      super.attributeChangedCallback(name, oldval, this.class);
+    }
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -22,11 +31,8 @@ export class PWCPageHeader extends LitElement {
   }
 
   protected render() {
-    // const { class: additionalClass } = this;
-    // const classes = classnames(additionalClass, 'pf-c-page__header');
-    const classes = 'pf-c-page__header';
     return html`
-      <header role="banner" class="${classes}"><slot></slot></header>
+      <header role="banner" class="${this.defaultClass}"><slot></slot></header>
     `;
   }
 }

--- a/packages/pwc-page/src/pwc-page.story.js
+++ b/packages/pwc-page/src/pwc-page.story.js
@@ -24,9 +24,9 @@ storiesOf('Page', module)
       <section style="padding: 20px">
         <h1 class="pf-c-title pf-m-3xl">Page</h1>
         <br />
-        <pwc-page class="pf-c-page ${additionalClasses}">
-          <pwc-page-header class="pf-c-page__header">
-            <pwc-page-header-brand class="pf-c-page__header-brand">
+        <pwc-page class="${additionalClasses}">
+          <pwc-page-header>
+            <pwc-page-header-brand>
               <pwc-page-header-brand-link>
                 <img
                   class="pf-c-brand"
@@ -35,7 +35,7 @@ storiesOf('Page', module)
                 />
               </pwc-page-header-brand-link>
             </pwc-page-header-brand>
-            <pwc-page-header-tools class="pf-c-page__header-tools">
+            <pwc-page-header-tools>
               <div class="pf-c-page__header-tools-group">
                 <button class="pf-c-button pf-m-plain" type="button" aria-label="Alerts">
                   <svg

--- a/packages/pwc-page/src/pwc-page.ts
+++ b/packages/pwc-page/src/pwc-page.ts
@@ -1,17 +1,26 @@
-// import classnames from 'classnames';
+import classnames from 'classnames';
 import { html, property, customElement, LitElement } from 'lit-element';
 import styles from './pwc-page.css';
 
 /**
- * Page.
+ * Page
  */
 @customElement('pwc-page')
 export class PWCPage extends LitElement {
+  protected defaultClass = 'pf-c-page';
+
   /**
    * Additional button classes
    */
-  @property({ reflect: false })
-  class = '';
+  @property({ type: String, reflect: true })
+  class = this.defaultClass;
+
+  public attributeChangedCallback(name, oldval, newval) {
+    if (name === 'class') {
+      this.class = classnames(this.defaultClass, newval);
+      super.attributeChangedCallback(name, oldval, this.class);
+    }
+  }
 
   protected createRenderRoot() {
     return this.attachShadow({ mode: 'open', delegatesFocus: true });


### PR DESCRIPTION
This moves  hard-coded class names from the story to page web components. Added an `attributeChanged` callback to append extra class names to the default.

Also added a clean target